### PR TITLE
React Router Hotfix

### DIFF
--- a/frontend/src/components/Main/Main.js
+++ b/frontend/src/components/Main/Main.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import axios from 'axios';
 import dayjs from 'dayjs';
-import { withRouter } from 'react-router';
+import { withRouter } from 'react-router-dom';
 import SingleRoom from '../SingleRoom/SingleRoom';
 import FullSchedule from '../FullSchedule/FullSchedule';
 import GenericInfoSection from '../GenericInfoSection/GenericInfoSection';


### PR DESCRIPTION
Added dom to the 'react-router' import so it's now 'react-router-dom' due to the node guide for react-router saying I should never import directly from react-router which I did oops