### PR TITLE
Frontend: Fixing a Bug

### DIFF
--- a/frontend/src/components/Main/Main.js
+++ b/frontend/src/components/Main/Main.js
@@ -97,8 +97,9 @@ class Main extends React.Component {
             return key.location.includes(filterKeyword) 
         });
 
-        if (filteredPanels.length > 1)
-            gaylordRoomExtr = filteredPanels[0].location.match(/\(([^)]+)\)/)[1];
+        if (filteredPanels.length >= 1) {
+            gaylordRoomExtr = filteredPanels[0].location.match(/\(([^)]+)\)/)?.[1] ?? "N/A";
+        }
 
         this.setState({ schedule: filteredPanels, gaylordRoom: gaylordRoomExtr });
         return filteredPanels;


### PR DESCRIPTION
* Fixes a bug for locations that don't have gaylord room names in parenthesis. As a result of this, the display would error out when visiting the page for those locations. Example is the Belvedere Lobby Bar as shown below:

<img width="1246" alt="Screen Shot 2022-01-04 at 12 39 26 AM" src="https://user-images.githubusercontent.com/25261175/148014375-e17211b5-661a-48b1-93c7-1a31decf1613.png">